### PR TITLE
[fix] #3 - pwa 트리거 기능 수정 및 types, utils 분리

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,25 +1,22 @@
 import "@/styles/globals.css";
-import { BeforeInstallPromptEvent } from '@/types';
+import { BeforeInstallPromptEvent } from '@/types/global';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from "next/app";
 import { useEffect, useState } from 'react';
 
 const queryClient = new QueryClient()
 
-declare global {
-  export interface WindowEventMap {
-    beforeinstallprompt: BeforeInstallPromptEvent;
-  }
-}
-
 export default function App({ Component, pageProps }: AppProps) {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | undefined>(undefined);
 
   useEffect(() => {
-    window.addEventListener("beforeinstallprompt", (e) => {
+    const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       e.preventDefault()
       setDeferredPrompt(e)
-    })
+    }
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt)
+
     if("serviceWorker" in navigator) {
       navigator.serviceWorker
       .register("/sw.js")
@@ -27,17 +24,15 @@ export default function App({ Component, pageProps }: AppProps) {
       .catch(() => console.log("failed"))
     }
     return () => {
-      window.removeEventListener("beforeinstallprompt", (e) => {
-        e.preventDefault()
-        setDeferredPrompt(e)
-      });
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
     }
-  })
+  }, [])
+
   return (
   <QueryClientProvider client={queryClient}>
     <Component
       {...pageProps}
-      deferedPrompt={deferredPrompt}
+      deferredPrompt={deferredPrompt}
       setDeferredPrompt={setDeferredPrompt}
     />
   </QueryClientProvider>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,31 +2,29 @@ import Head from "next/head";
 import Image from "next/image";
 import { Inter } from "next/font/google";
 import styles from "@/styles/Home.module.css";
-import { BeforeInstallPromptEvent } from '@/types';
+import { BeforeInstallPromptEvent } from '@/types/global';
 import { Dispatch, SetStateAction } from 'react';
+import { checkUnsupportedBrowser } from "@/utils/index";
 
 const inter = Inter({ subsets: ["latin"] });
 
-export default function Home({ deferredPrompt } : { deferredPrompt: BeforeInstallPromptEvent}, setDeferredPrompt : Dispatch<SetStateAction<BeforeInstallPromptEvent | undefined>> ) {
-  const isIos = () => {
-    const userAgent = window.navigator.userAgent.toLowerCase()
-    return /iphone|ipad|ipod/.test(userAgent)
-  }
+export default function Home({ deferredPrompt, setDeferredPrompt } : { deferredPrompt: BeforeInstallPromptEvent, setDeferredPrompt : Dispatch<SetStateAction<BeforeInstallPromptEvent | undefined>>}) {
 
   const promptAppInstall = async () => {
-    if (isIos()) {
+    const isUnsupportedBrowser = checkUnsupportedBrowser();
+    if (isUnsupportedBrowser) {
       alert("공유 아이콘 -> 홈 화면에 추가를 클릭해 앱으로 편리하게 이용해보세요!")
     }
-    if (!isIos()) {
+    if (!isUnsupportedBrowser) {
       if (deferredPrompt) {
         deferredPrompt.prompt()
         await deferredPrompt.userChoice
         setDeferredPrompt(undefined)
-        } else {
+      } else {
           alert("이미 저희 서비스를 설치해주셨어요!")
-        }
       }
     }
+  }
 
   return (
     <>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,3 +1,9 @@
+declare global {
+  export interface WindowEventMap {
+    beforeinstallprompt: BeforeInstallPromptEvent;
+  }
+}
+
 export interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
   readonly userChoice: Promise<{

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,7 @@
+export const checkUnsupportedBrowser = () => {
+    const userAgent = window.navigator.userAgent.toLowerCase()
+    return (
+      (userAgent.indexOf('safari') > -1 && userAgent.indexOf('chrome') <= -1 && userAgent.indexOf('chromium') <= -1 ) ||
+      (userAgent.indexOf('firefox') > -1 && userAgent.indexOf('seamonkey') <= -1)
+    );
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
#3

## 예상 리뷰 시간
10min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
* _app.tsx 파일 deferredPrompt 오타 수정
* handleBeforeInstallPrompt 콜백 함수 정의 및 useEffect 처음 마운트될 때만 실행
* WindowEventMap types로 분리 & checkUnsupportedBrowser() utils로 분리
* index.tsx Home props 수정

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
* Chrome/Android - 설치 전 버튼 클릭
<img width="375" alt="image" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/78e9a84a-8bd8-45c2-a139-4ec90da8ae59">

* Chrome/Android - 설치 후 버튼 클릭
<img width="483" alt="image" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/0d5233de-8bee-4589-a276-95a123c87aa5">

* Safari/Firefox/iOS - 설치 전/후 버튼 클릭
<img width="492" alt="image" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/23f4162f-4e41-4a62-a2f6-b98e9578557e">


## 기타
Safari, Firefox, Chrome 환경에서 확인하였으나 안드로이드 환경에서는 확인하지 못했습니다. 부탁드립니다!